### PR TITLE
docs: Include VSCODE_SERVE_MODE in run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ docker run --rm \
   --hostname vscode \
   -p 8000:8000 \
   -e VSCODE_KEYRING_PASS="mysecretpassword" \
+  -e VSCODE_SERVE_MODE=serve-local \
   -v /<host_folder_data>:/root/.vscode-server \
   ahmadnassri/vscode-server:latest
 ```

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ docker run --rm \
   --hostname vscode \
   -p 8000:8000 \
   -e VSCODE_KEYRING_PASS="mysecretpassword" \
-  -e VSCODE_SERVE_MODE=serve-local \
   -v /<host_folder_data>:/root/.vscode-server \
   ahmadnassri/vscode-server:latest
 ```
@@ -53,10 +52,10 @@ docker run --rm \
 [release-img]: https://badgen.net/github/release/ahmadnassri/docker-vscode-server
 
 [size-url]: https://hub.docker.com/r/ahmadnassri/vscode-server
-[size-img]: https://badgen.net/docker/size/ahmadnassri/vscode-server
+[size-img]: https://badgen.net/docker/size/ahmadnassri/vscode-server?label=image%20size
 
 [docker-url]: https://hub.docker.com/r/ahmadnassri/vscode-server
 [docker-img]: https://badgen.net/badge/icon/docker%20hub?icon=docker&label
 
-[github-url]: https://github.com/ahmadnassri/docker-vscode-server/pkgs/container/vscode-server
+[github-url]: https://github.com/users/ahmadnassri/packages/container/package/vscode-server
 [github-img]: https://badgen.net/badge/icon/github%20registry?icon=github&label

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,6 +22,7 @@ docker run --rm \
   --hostname vscode \
   -p 8000:8000 \
   -e VSCODE_KEYRING_PASS="mysecretpassword" \
+  -e VSCODE_SERVE_MODE=serve-local \
   -v /<host_folder_data>:/root/.vscode-server \
   ahmadnassri/vscode-server:latest
 ```


### PR DESCRIPTION
If we run without VSCODE_SERVE_MODE, the container will fail with the following error:
/usr/local/bin/start-vscode: line 6: VSCODE_SERVE_MODE: unbound variable

Ref: https://forums.unraid.net/topic/126755-support-ahmads-templates/?do=findComment&comment=1157120